### PR TITLE
Fix aws provider version

### DIFF
--- a/modules/datastore/versions.tf
+++ b/modules/datastore/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = ">= 3.38.0, < 4.0"
     }
     random = {
       source = "hashicorp/random"


### PR DESCRIPTION
There are some breaking changes for [S3 Bucket resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) in 4.0 