### PR TITLE
Restrict autoscaling privileges to AWSBatch* resources

### DIFF
--- a/modules/computation/iam-batch-execution.tf
+++ b/modules/computation/iam-batch-execution.tf
@@ -75,16 +75,7 @@ data "aws_iam_policy_document" "custom_access_policy" {
       "autoscaling:DescribeAutoScalingGroups",
       "autoscaling:DescribeLaunchConfigurations",
       "autoscaling:DescribeAutoScalingInstances",
-      "autoscaling:CreateLaunchConfiguration",
-      "autoscaling:CreateAutoScalingGroup",
-      "autoscaling:UpdateAutoScalingGroup",
-      "autoscaling:SetDesiredCapacity",
-      "autoscaling:DeleteLaunchConfiguration",
-      "autoscaling:DeleteAutoScalingGroup",
       "autoscaling:CreateOrUpdateTags",
-      "autoscaling:SuspendProcesses",
-      "autoscaling:PutNotificationConfiguration",
-      "autoscaling:TerminateInstanceInAutoScalingGroup",
       "ecs:DescribeClusters",
       "ecs:DescribeContainerInstances",
       "ecs:DescribeTaskDefinition",
@@ -115,6 +106,37 @@ data "aws_iam_policy_document" "custom_access_policy" {
 
     resources = [
       "*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "autoscaling:CreateLaunchConfiguration",
+      "autoscaling:DeleteLaunchConfiguration",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:autoscaling:*:*:launchConfiguration:*:launchConfigurationName/AWSBatch*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "autoscaling:CreateAutoScalingGroup",
+      "autoscaling:UpdateAutoScalingGroup",
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:DeleteAutoScalingGroup",
+      "autoscaling:SuspendProcesses",
+      "autoscaling:PutNotificationConfiguration",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/AWSBatch*"
     ]
   }
 }


### PR DESCRIPTION
In this PR I restrict the `autoscaling` privileges to `AWSBatch*` resources for the `batch_execution_role`.

This addresses https://github.com/outerbounds/terraform-aws-metaflow/issues/11.