### PR TITLE
Revert "Restrict autoscaling privileges to AWSBatch* resources"

### DIFF
--- a/modules/computation/iam-batch-execution.tf
+++ b/modules/computation/iam-batch-execution.tf
@@ -75,7 +75,16 @@ data "aws_iam_policy_document" "custom_access_policy" {
       "autoscaling:DescribeAutoScalingGroups",
       "autoscaling:DescribeLaunchConfigurations",
       "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:CreateLaunchConfiguration",
+      "autoscaling:CreateAutoScalingGroup",
+      "autoscaling:UpdateAutoScalingGroup",
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:DeleteLaunchConfiguration",
+      "autoscaling:DeleteAutoScalingGroup",
       "autoscaling:CreateOrUpdateTags",
+      "autoscaling:SuspendProcesses",
+      "autoscaling:PutNotificationConfiguration",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
       "ecs:DescribeClusters",
       "ecs:DescribeContainerInstances",
       "ecs:DescribeTaskDefinition",
@@ -106,37 +115,6 @@ data "aws_iam_policy_document" "custom_access_policy" {
 
     resources = [
       "*"
-    ]
-  }
-
-  statement {
-    actions = [
-      "autoscaling:CreateLaunchConfiguration",
-      "autoscaling:DeleteLaunchConfiguration",
-    ]
-
-    effect = "Allow"
-
-    resources = [
-      "arn:aws:autoscaling:*:*:launchConfiguration:*:launchConfigurationName/AWSBatch*"
-    ]
-  }
-
-  statement {
-    actions = [
-      "autoscaling:CreateAutoScalingGroup",
-      "autoscaling:UpdateAutoScalingGroup",
-      "autoscaling:SetDesiredCapacity",
-      "autoscaling:DeleteAutoScalingGroup",
-      "autoscaling:SuspendProcesses",
-      "autoscaling:PutNotificationConfiguration",
-      "autoscaling:TerminateInstanceInAutoScalingGroup",
-    ]
-
-    effect = "Allow"
-
-    resources = [
-      "arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/AWSBatch*"
     ]
   }
 }


### PR DESCRIPTION
Reverts outerbounds/terraform-aws-metaflow#12

@oavdeev does this work for you? I'm afraid I might have broken some other permissions. I'm now getting the following error:
```
Error: error waiting for Batch Compute Environment (custom-metaflow-cpu20220422132353471700000001) create: unexpected state 'INVALID', wanted target 'VALID'. last error: CLIENT_ERROR - User: arn:aws:sts::[REDACTED]:assumed-role/custom-metaflow-batch-execution-role/aws-batch is not authorized to perform: autoscaling:CreateAutoScalingGroup on resource: arn:aws:autoscaling:eu-west-1:[REDACTED]:autoScalingGroup:*:autoScalingGroupName/custom-metaflow-cpu20220422132353471700000001-asg-59cfd8b7-b102-3b1d-84fe-2c34f232b239 because no identity-based policy allows the autoscaling:CreateAutoScalingGroup action
```
It seems that the `resource_prefix` (in this case `custom-metaflow`) is being prepended to the autoscaling group name. I couldn't find where this is defined. I re-built with `0.3.2` and this error went away (but I got another one 😬)