### PR TITLE
Expose the internal attribute of the ALB

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ You can find a more complete example that uses this module but also includes set
 | <a name="input_subnet1_id"></a> [subnet1\_id](#input\_subnet1\_id) | First subnet used for availability zone redundancy | `string` | n/a | yes |
 | <a name="input_subnet2_id"></a> [subnet2\_id](#input\_subnet2\_id) | Second subnet used for availability zone redundancy | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | aws tags | `map(string)` | n/a | yes |
+| <a name="input_ui_alb_internal"></a> [ui\_alb\_internal](#input\_ui\_alb\_internal) | Defines whether the ALB for the UI is internal | `bool` | `false` | no |
 | <a name="input_ui_certificate_arn"></a> [ui\_certificate\_arn](#input\_ui\_certificate\_arn) | SSL certificate for UI. If set to empty string, UI is disabled. | `string` | `""` | no |
 | <a name="input_ui_static_container_image"></a> [ui\_static\_container\_image](#input\_ui\_static\_container\_image) | Container image for the UI frontend app | `string` | `""` | no |
 | <a name="input_vpc_cidr_block"></a> [vpc\_cidr\_block](#input\_vpc\_cidr\_block) | The VPC CIDR block that we'll access list on our Metadata Service API to allow all internal communications | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,7 @@ module "metaflow-ui" {
   subnet2_id                      = var.subnet2_id
   ui_backend_container_image      = local.metadata_service_container_image
   ui_static_container_image       = local.ui_static_container_image
+  alb_internal                    = var.ui_alb_internal
 
   METAFLOW_DATASTORE_SYSROOT_S3      = module.metaflow-datastore.METAFLOW_DATASTORE_SYSROOT_S3
   certificate_arn                    = var.ui_certificate_arn

--- a/modules/ui/README.md
+++ b/modules/ui/README.md
@@ -10,6 +10,7 @@ The services are deployed behind an AWS ALB, and the module will output the ALB 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_METAFLOW_DATASTORE_SYSROOT_S3"></a> [METAFLOW\_DATASTORE\_SYSROOT\_S3](#input\_METAFLOW\_DATASTORE\_SYSROOT\_S3) | METAFLOW\_DATASTORE\_SYSROOT\_S3 value | `string` | n/a | yes |
+| <a name="input_alb_internal"></a> [alb\_internal](#input\_alb\_internal) | Defines whether the ALB is internal | `bool` | `false` | no |
 | <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | SSL certificate ARN. The certificate will be used by the UI load balancer. | `string` | n/a | yes |
 | <a name="input_database_password"></a> [database\_password](#input\_database\_password) | The database password | `string` | n/a | yes |
 | <a name="input_database_username"></a> [database\_username](#input\_database\_username) | The database username | `string` | n/a | yes |

--- a/modules/ui/ec2.tf
+++ b/modules/ui/ec2.tf
@@ -75,7 +75,7 @@ resource "aws_security_group" "ui_lb_security_group" {
 
 resource "aws_lb" "this" {
   name               = "${var.resource_prefix}alb${var.resource_suffix}"
-  internal           = false
+  internal           = var.alb_internal
   load_balancer_type = "application"
   subnets            = [var.subnet1_id, var.subnet2_id]
   security_groups = [

--- a/modules/ui/variables.tf
+++ b/modules/ui/variables.tf
@@ -115,3 +115,9 @@ variable "ui_allow_list" {
   description = "A list of CIDRs the UI will be available to"
   default     = ["0.0.0.0/0"]
 }
+
+variable "alb_internal" {
+  type        = bool
+  description = "Defines whether the ALB is internal"
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,12 @@ variable "tags" {
   type        = map(string)
 }
 
+variable "ui_alb_internal" {
+  type        = bool
+  description = "Defines whether the ALB for the UI is internal"
+  default     = false
+}
+
 # variables from infra project that defines the VPC we will deploy to
 
 variable "subnet1_id" {


### PR DESCRIPTION
In this PR I expose the `internal` attribute of the ALB as a variable in the `ui` module, and expose that variable in the main module. This allows a fully private UI which accepts only traffic from within the VPC.