### PR TITLE
Add UI ALB ARN to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,5 +140,6 @@ You can find a more complete example that uses this module but also includes set
 | <a name="output_metaflow_s3_bucket_arn"></a> [metaflow\_s3\_bucket\_arn](#output\_metaflow\_s3\_bucket\_arn) | The ARN of the bucket we'll be using as blob storage |
 | <a name="output_metaflow_s3_bucket_name"></a> [metaflow\_s3\_bucket\_name](#output\_metaflow\_s3\_bucket\_name) | The name of the bucket we'll be using as blob storage |
 | <a name="output_migration_function_arn"></a> [migration\_function\_arn](#output\_migration\_function\_arn) | ARN of DB Migration Function |
+| <a name="output_ui_alb_arn"></a> [ui\_alb\_arn](#output\_ui\_alb\_arn) | UI ALB ARN |
 | <a name="output_ui_alb_dns_name"></a> [ui\_alb\_dns\_name](#output\_ui\_alb\_dns\_name) | UI ALB DNS name |
 <!-- END_TF_DOCS -->

--- a/modules/ui/README.md
+++ b/modules/ui/README.md
@@ -37,5 +37,6 @@ The services are deployed behind an AWS ALB, and the module will output the ALB 
 
 | Name | Description |
 |------|-------------|
+| <a name="output_alb_arn"></a> [alb\_arn](#output\_alb\_arn) | UI ALB ARN |
 | <a name="output_alb_dns_name"></a> [alb\_dns\_name](#output\_alb\_dns\_name) | UI ALB DNS name |
 <!-- END_TF_DOCS -->

--- a/modules/ui/outputs.tf
+++ b/modules/ui/outputs.tf
@@ -3,3 +3,8 @@ output "alb_dns_name" {
   value       = aws_lb.this.dns_name
   description = "UI ALB DNS name"
 }
+
+output "alb_arn" {
+  value       = aws_lb.this.arn
+  description = "UI ALB ARN"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -118,3 +118,8 @@ output "ui_alb_dns_name" {
   value       = (length(module.metaflow-ui) > 0) ? module.metaflow-ui[0].alb_dns_name : ""
   description = "UI ALB DNS name"
 }
+
+output "ui_alb_arn" {
+  value       = (length(module.metaflow-ui) > 0) ? module.metaflow-ui[0].alb_arn : ""
+  description = "UI ALB ARN"
+}


### PR DESCRIPTION
In this PR I add the ARN of the UI's ALB to the outputs of the module. This allows other resources to reference it (e.g. create a route53 record for the ALB without hard-coding the IP address).