### PR TITLE
omit image id in launch template

### DIFF
--- a/modules/computation/ec2.tf
+++ b/modules/computation/ec2.tf
@@ -15,8 +15,6 @@ resource "aws_launch_template" "cpu" {
     arn = aws_iam_instance_profile.ecs_instance_role.arn
   }
 
-  image_id = jsondecode(data.aws_ssm_parameter.ecs_optimized_cpu_ami.value)["image_id"]
-
   block_device_mappings {
     device_name = "/dev/xvda"
 


### PR DESCRIPTION
Let AWS Batch decide so it can pick a GPU-optimized version for GPU-enabled compute environments