### PR TITLE
Add database name to submodule inputs

### DIFF
--- a/examples/eks/metaflow.tf
+++ b/examples/eks/metaflow.tf
@@ -49,6 +49,7 @@ module "metaflow-metadata-service" {
 
   access_list_cidr_blocks          = []
   api_basic_auth                   = true
+  database_name                    = module.metaflow-datastore.database_name
   database_password                = module.metaflow-datastore.database_password
   database_username                = module.metaflow-datastore.database_username
   datastore_s3_bucket_kms_key_arn  = module.metaflow-datastore.datastore_s3_bucket_kms_key_arn

--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,7 @@ module "metaflow-metadata-service" {
 
   access_list_cidr_blocks          = var.access_list_cidr_blocks
   api_basic_auth                   = var.api_basic_auth
+  database_name                    = module.metaflow-datastore.database_name
   database_password                = module.metaflow-datastore.database_password
   database_username                = module.metaflow-datastore.database_username
   datastore_s3_bucket_kms_key_arn  = module.metaflow-datastore.datastore_s3_bucket_kms_key_arn
@@ -43,6 +44,7 @@ module "metaflow-ui" {
   resource_prefix = local.resource_prefix
   resource_suffix = local.resource_suffix
 
+  database_name                   = module.metaflow-datastore.database_name
   database_password               = module.metaflow-datastore.database_password
   database_username               = module.metaflow-datastore.database_username
   datastore_s3_bucket_kms_key_arn = module.metaflow-datastore.datastore_s3_bucket_kms_key_arn

--- a/modules/datastore/README.md
+++ b/modules/datastore/README.md
@@ -37,6 +37,7 @@ To read more, see [the Metaflow docs](https://docs.metaflow.org/metaflow-on-aws/
 |------|-------------|
 | <a name="output_METAFLOW_DATASTORE_SYSROOT_S3"></a> [METAFLOW\_DATASTORE\_SYSROOT\_S3](#output\_METAFLOW\_DATASTORE\_SYSROOT\_S3) | Amazon S3 URL for Metaflow DataStore |
 | <a name="output_METAFLOW_DATATOOLS_S3ROOT"></a> [METAFLOW\_DATATOOLS\_S3ROOT](#output\_METAFLOW\_DATATOOLS\_S3ROOT) | Amazon S3 URL for Metaflow DataTools |
+| <a name="output_database_name"></a> [database\_name](#output\_database\_name) | The database name |
 | <a name="output_database_password"></a> [database\_password](#output\_database\_password) | The database password |
 | <a name="output_database_username"></a> [database\_username](#output\_database\_username) | The database username |
 | <a name="output_datastore_s3_bucket_kms_key_arn"></a> [datastore\_s3\_bucket\_kms\_key\_arn](#output\_datastore\_s3\_bucket\_kms\_key\_arn) | The ARN of the KMS key used to encrypt the Metaflow datastore S3 bucket |

--- a/modules/datastore/outputs.tf
+++ b/modules/datastore/outputs.tf
@@ -8,6 +8,11 @@ output "METAFLOW_DATASTORE_SYSROOT_S3" {
   description = "Amazon S3 URL for Metaflow DataStore"
 }
 
+output "database_name" {
+  value       = var.db_name
+  description = "The database name"
+}
+
 output "database_password" {
   value       = random_password.this.result
   description = "The database password"

--- a/modules/metadata-service/README.md
+++ b/modules/metadata-service/README.md
@@ -17,6 +17,7 @@ If the `access_list_cidr_blocks` variable is set, only traffic originating from 
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_list_cidr_blocks"></a> [access\_list\_cidr\_blocks](#input\_access\_list\_cidr\_blocks) | List of CIDRs we want to grant access to our Metaflow Metadata Service. Usually this is our VPN's CIDR blocks. | `list(string)` | n/a | yes |
 | <a name="input_api_basic_auth"></a> [api\_basic\_auth](#input\_api\_basic\_auth) | Enable basic auth for API Gateway? (requires key export) | `bool` | `true` | no |
+| <a name="input_database_name"></a> [database\_name](#input\_database\_name) | The database name | `string` | `"metaflow"` | no |
 | <a name="input_database_password"></a> [database\_password](#input\_database\_password) | The database password | `string` | n/a | yes |
 | <a name="input_database_username"></a> [database\_username](#input\_database\_username) | The database username | `string` | n/a | yes |
 | <a name="input_datastore_s3_bucket_kms_key_arn"></a> [datastore\_s3\_bucket\_kms\_key\_arn](#input\_datastore\_s3\_bucket\_kms\_key\_arn) | The ARN of the KMS key used to encrypt the Metaflow datastore S3 bucket | `string` | n/a | yes |

--- a/modules/metadata-service/ecs.tf
+++ b/modules/metadata-service/ecs.tf
@@ -33,7 +33,7 @@ resource "aws_ecs_task_definition" "this" {
     ],
     "environment": [
       {"name": "MF_METADATA_DB_HOST", "value": "${replace(var.rds_master_instance_endpoint, ":5432", "")}"},
-      {"name": "MF_METADATA_DB_NAME", "value": "metaflow"},
+      {"name": "MF_METADATA_DB_NAME", "value": "${var.database_name}"},
       {"name": "MF_METADATA_DB_PORT", "value": "5432"},
       {"name": "MF_METADATA_DB_PSWD", "value": "${var.database_password}"},
       {"name": "MF_METADATA_DB_USER", "value": "${var.database_username}"}

--- a/modules/metadata-service/variables.tf
+++ b/modules/metadata-service/variables.tf
@@ -9,6 +9,12 @@ variable "api_basic_auth" {
   description = "Enable basic auth for API Gateway? (requires key export)"
 }
 
+variable "database_name" {
+  type        = string
+  default     = "metaflow"
+  description = "The database name"
+}
+
 variable "database_password" {
   type        = string
   description = "The database password"

--- a/modules/ui/README.md
+++ b/modules/ui/README.md
@@ -12,6 +12,7 @@ The services are deployed behind an AWS ALB, and the module will output the ALB 
 | <a name="input_METAFLOW_DATASTORE_SYSROOT_S3"></a> [METAFLOW\_DATASTORE\_SYSROOT\_S3](#input\_METAFLOW\_DATASTORE\_SYSROOT\_S3) | METAFLOW\_DATASTORE\_SYSROOT\_S3 value | `string` | n/a | yes |
 | <a name="input_alb_internal"></a> [alb\_internal](#input\_alb\_internal) | Defines whether the ALB is internal | `bool` | `false` | no |
 | <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | SSL certificate ARN. The certificate will be used by the UI load balancer. | `string` | n/a | yes |
+| <a name="input_database_name"></a> [database\_name](#input\_database\_name) | The database name | `string` | `"metaflow"` | no |
 | <a name="input_database_password"></a> [database\_password](#input\_database\_password) | The database password | `string` | n/a | yes |
 | <a name="input_database_username"></a> [database\_username](#input\_database\_username) | The database username | `string` | n/a | yes |
 | <a name="input_datastore_s3_bucket_kms_key_arn"></a> [datastore\_s3\_bucket\_kms\_key\_arn](#input\_datastore\_s3\_bucket\_kms\_key\_arn) | The ARN of the KMS key used to encrypt the Metaflow datastore S3 bucket | `string` | n/a | yes |

--- a/modules/ui/locals.tf
+++ b/modules/ui/locals.tf
@@ -17,7 +17,7 @@ locals {
 
   default_ui_backend_env_vars = {
     "MF_METADATA_DB_HOST"           = "${replace(var.rds_master_instance_endpoint, ":5432", "")}"
-    "MF_METADATA_DB_NAME"           = "metaflow"
+    "MF_METADATA_DB_NAME"           = "${var.database_name}"
     "MF_METADATA_DB_PORT"           = "5432"
     "MF_METADATA_DB_PSWD"           = "${var.database_password}"
     "MF_METADATA_DB_USER"           = "${var.database_username}"

--- a/modules/ui/variables.tf
+++ b/modules/ui/variables.tf
@@ -1,3 +1,8 @@
+variable "database_name" {
+  type        = string
+  default     = "metaflow"
+  description = "The database name"
+}
 
 variable "database_password" {
   type        = string


### PR DESCRIPTION
Currently if `db_name` is overwritten in the `datastore` inputs, the `ui`  and `metadata-service` would break because they have database name hard coded as `metaflow`.

This PR fixed it by adding the db name to `datastore` outputs, and to the others' inputs.