### PR TITLE
Enable internal traffic from multiple VPCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ You can find a more complete example that uses this module but also includes set
 | <a name="input_ui_allow_list"></a> [ui\_allow\_list](#input\_ui\_allow\_list) | List of CIDRs we want to grant access to our Metaflow UI Service. Usually this is our VPN's CIDR blocks. | `list(string)` | `[]` | no |
 | <a name="input_ui_certificate_arn"></a> [ui\_certificate\_arn](#input\_ui\_certificate\_arn) | SSL certificate for UI. If set to empty string, UI is disabled. | `string` | `""` | no |
 | <a name="input_ui_static_container_image"></a> [ui\_static\_container\_image](#input\_ui\_static\_container\_image) | Container image for the UI frontend app | `string` | `""` | no |
-| <a name="input_vpc_cidr_block"></a> [vpc\_cidr\_block](#input\_vpc\_cidr\_block) | The VPC CIDR block that we'll access list on our Metadata Service API to allow all internal communications | `string` | n/a | yes |
+| <a name="input_vpc_cidr_blocks"></a> [vpc\_cidr\_blocks](#input\_vpc\_cidr\_blocks) | The VPC CIDR blocks that we'll access list on our Metadata Service API to allow all internal communications | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The id of the single VPC we stood up for all Metaflow resources to exist in. | `string` | n/a | yes |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ You can find a more complete example that uses this module but also includes set
 | <a name="input_ui_allow_list"></a> [ui\_allow\_list](#input\_ui\_allow\_list) | List of CIDRs we want to grant access to our Metaflow UI Service. Usually this is our VPN's CIDR blocks. | `list(string)` | `[]` | no |
 | <a name="input_ui_certificate_arn"></a> [ui\_certificate\_arn](#input\_ui\_certificate\_arn) | SSL certificate for UI. If set to empty string, UI is disabled. | `string` | `""` | no |
 | <a name="input_ui_static_container_image"></a> [ui\_static\_container\_image](#input\_ui\_static\_container\_image) | Container image for the UI frontend app | `string` | `""` | no |
-| <a name="input_vpc_cidr_blocks"></a> [vpc\_cidr\_blocks](#input\_vpc\_cidr\_blocks) | The VPC CIDR blocks that we'll access list on our Metadata Service API to allow all internal communications | `string` | n/a | yes |
+| <a name="input_vpc_cidr_blocks"></a> [vpc\_cidr\_blocks](#input\_vpc\_cidr\_blocks) | The VPC CIDR blocks that we'll access list on our Metadata Service API to allow all internal communications | `list(string)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The id of the single VPC we stood up for all Metaflow resources to exist in. | `string` | n/a | yes |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ module "metaflow" {
   enable_step_functions = false
   subnet1_id            = module.vpc.public_subnets[0]
   subnet2_id            = module.vpc.public_subnets[1]
-  vpc_cidr_block        = module.vpc.vpc_cidr_block
+  vpc_cidr_blocks       = module.vpc.vpc_cidr_blocks
   vpc_id                = module.vpc.vpc_id
 
   tags = {

--- a/examples/eks/metaflow.tf
+++ b/examples/eks/metaflow.tf
@@ -60,7 +60,7 @@ module "metaflow-metadata-service" {
   s3_bucket_arn                    = module.metaflow-datastore.s3_bucket_arn
   subnet1_id                       = module.vpc.private_subnets[0]
   subnet2_id                       = module.vpc.private_subnets[1]
-  vpc_cidr_block                   = module.vpc.vpc_cidr_block
+  vpc_cidr_blocks                  = module.vpc.vpc_cidr_blocks
 
   standard_tags = local.tags
 }

--- a/examples/eks/metaflow.tf
+++ b/examples/eks/metaflow.tf
@@ -60,7 +60,7 @@ module "metaflow-metadata-service" {
   s3_bucket_arn                    = module.metaflow-datastore.s3_bucket_arn
   subnet1_id                       = module.vpc.private_subnets[0]
   subnet2_id                       = module.vpc.private_subnets[1]
-  vpc_cidr_blocks                  = module.vpc.vpc_cidr_blocks
+  vpc_cidr_blocks                  = [module.vpc.vpc_cidr_block]
 
   standard_tags = local.tags
 }

--- a/examples/eks/metaflow.tf
+++ b/examples/eks/metaflow.tf
@@ -42,7 +42,7 @@ module "metaflow-common" {
 
 module "metaflow-metadata-service" {
   source  = "outerbounds/metaflow/aws//modules/metadata-service"
-  version = "0.3.2"
+  version = "0.7.0"
 
   resource_prefix = local.resource_prefix
   resource_suffix = local.resource_suffix

--- a/examples/minimal/minimal_example.tf
+++ b/examples/minimal/minimal_example.tf
@@ -46,7 +46,7 @@ module "metaflow" {
   enable_step_functions = false
   subnet1_id            = module.vpc.public_subnets[0]
   subnet2_id            = module.vpc.public_subnets[1]
-  vpc_cidr_block        = module.vpc.vpc_cidr_block
+  vpc_cidr_blocks       = module.vpc.vpc_cidr_blocks
   vpc_id                = module.vpc.vpc_id
 
   tags = {

--- a/examples/minimal/minimal_example.tf
+++ b/examples/minimal/minimal_example.tf
@@ -46,7 +46,7 @@ module "metaflow" {
   enable_step_functions = false
   subnet1_id            = module.vpc.public_subnets[0]
   subnet2_id            = module.vpc.public_subnets[1]
-  vpc_cidr_blocks       = module.vpc.vpc_cidr_blocks
+  vpc_cidr_blocks       = [module.vpc.vpc_cidr_block]
   vpc_id                = module.vpc.vpc_id
 
   tags = {

--- a/examples/minimal/minimal_example.tf
+++ b/examples/minimal/minimal_example.tf
@@ -38,7 +38,7 @@ module "vpc" {
 
 module "metaflow" {
   source  = "outerbounds/metaflow/aws"
-  version = "0.5.2"
+  version = "0.7.0"
 
   resource_prefix = local.resource_prefix
   resource_suffix = local.resource_suffix

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ module "metaflow-metadata-service" {
   s3_bucket_arn                    = module.metaflow-datastore.s3_bucket_arn
   subnet1_id                       = var.subnet1_id
   subnet2_id                       = var.subnet2_id
-  vpc_cidr_block                   = var.vpc_cidr_block
+  vpc_cidr_blocks                  = var.vpc_cidr_blocks
 
   standard_tags = var.tags
 }

--- a/modules/metadata-service/README.md
+++ b/modules/metadata-service/README.md
@@ -35,7 +35,7 @@ If the `access_list_cidr_blocks` variable is set, only traffic originating from 
 | <a name="input_standard_tags"></a> [standard\_tags](#input\_standard\_tags) | The standard tags to apply to every AWS resource. | `map(string)` | n/a | yes |
 | <a name="input_subnet1_id"></a> [subnet1\_id](#input\_subnet1\_id) | First private subnet used for availability zone redundancy | `string` | n/a | yes |
 | <a name="input_subnet2_id"></a> [subnet2\_id](#input\_subnet2\_id) | Second private subnet used for availability zone redundancy | `string` | n/a | yes |
-| <a name="input_vpc_cidr_block"></a> [vpc\_cidr\_block](#input\_vpc\_cidr\_block) | The VPC CIDR block that we'll access list on our Metadata Service API to allow all internal communications | `string` | n/a | yes |
+| <a name="input_vpc_cidr_blocks"></a> [vpc\_cidr\_blocks](#input\_vpc\_cidr\_blocks) | The VPC CIDR blocks that we'll access list on our Metadata Service API to allow all internal communications | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/metadata-service/README.md
+++ b/modules/metadata-service/README.md
@@ -35,7 +35,7 @@ If the `access_list_cidr_blocks` variable is set, only traffic originating from 
 | <a name="input_standard_tags"></a> [standard\_tags](#input\_standard\_tags) | The standard tags to apply to every AWS resource. | `map(string)` | n/a | yes |
 | <a name="input_subnet1_id"></a> [subnet1\_id](#input\_subnet1\_id) | First private subnet used for availability zone redundancy | `string` | n/a | yes |
 | <a name="input_subnet2_id"></a> [subnet2\_id](#input\_subnet2\_id) | Second private subnet used for availability zone redundancy | `string` | n/a | yes |
-| <a name="input_vpc_cidr_blocks"></a> [vpc\_cidr\_blocks](#input\_vpc\_cidr\_blocks) | The VPC CIDR blocks that we'll access list on our Metadata Service API to allow all internal communications | `string` | n/a | yes |
+| <a name="input_vpc_cidr_blocks"></a> [vpc\_cidr\_blocks](#input\_vpc\_cidr\_blocks) | The VPC CIDR blocks that we'll access list on our Metadata Service API to allow all internal communications | `list(string)` | n/a | yes |
 
 ## Outputs
 

--- a/modules/metadata-service/ec2.tf
+++ b/modules/metadata-service/ec2.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "metadata_service_security_group" {
     from_port   = 8080
     to_port     = 8080
     protocol    = "tcp"
-    cidr_blocks = [var.vpc_cidr_block]
+    cidr_blocks = var.vpc_cidr_blocks
     description = "Allow API calls internally"
   }
 
@@ -15,7 +15,7 @@ resource "aws_security_group" "metadata_service_security_group" {
     from_port   = 8082
     to_port     = 8082
     protocol    = "tcp"
-    cidr_blocks = [var.vpc_cidr_block]
+    cidr_blocks = var.vpc_cidr_blocks
     description = "Allow API calls internally"
   }
 

--- a/modules/metadata-service/variables.tf
+++ b/modules/metadata-service/variables.tf
@@ -106,6 +106,6 @@ variable "subnet2_id" {
 }
 
 variable "vpc_cidr_blocks" {
-  type        = string
+  type        = list(string)
   description = "The VPC CIDR blocks that we'll access list on our Metadata Service API to allow all internal communications"
 }

--- a/modules/metadata-service/variables.tf
+++ b/modules/metadata-service/variables.tf
@@ -105,7 +105,7 @@ variable "subnet2_id" {
   description = "Second private subnet used for availability zone redundancy"
 }
 
-variable "vpc_cidr_block" {
+variable "vpc_cidr_blocks" {
   type        = string
-  description = "The VPC CIDR block that we'll access list on our Metadata Service API to allow all internal communications"
+  description = "The VPC CIDR blocks that we'll access list on our Metadata Service API to allow all internal communications"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -109,7 +109,7 @@ variable "subnet2_id" {
 }
 
 variable "vpc_cidr_blocks" {
-  type        = string
+  type        = list(string)
   description = "The VPC CIDR blocks that we'll access list on our Metadata Service API to allow all internal communications"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -108,9 +108,9 @@ variable "subnet2_id" {
   description = "Second subnet used for availability zone redundancy"
 }
 
-variable "vpc_cidr_block" {
+variable "vpc_cidr_blocks" {
   type        = string
-  description = "The VPC CIDR block that we'll access list on our Metadata Service API to allow all internal communications"
+  description = "The VPC CIDR blocks that we'll access list on our Metadata Service API to allow all internal communications"
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
In this PR I add support for allowing internal traffic from multiple VPCs. This is useful to allow traffic from resources from another VPC which is peered with Metaflow's VPC.

The change also aligns the variable with the `cidr_blocks` parameter of the security group resources, which expects a list of strings.

This is a breaking change but a fairly easy one to accommodate, as the existing CIDR block just needs to be passed as a list instead of a string.