### PR TITLE
Bump metadata service to 2.3.0

### DIFF
--- a/modules/common/locals.tf
+++ b/modules/common/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  default_metadata_service_container_image = "netflixoss/metaflow_metadata_service:v2.2.4"
+  default_metadata_service_container_image = "netflixoss/metaflow_metadata_service:v2.3.0"
   default_ui_static_container_image        = "public.ecr.aws/outerbounds/metaflow_ui:v1.1.2"
 }


### PR DESCRIPTION
Mostly to enable tag mutation (added in 2.2.5).