### PR TITLE
Make api gateway optional and adjust api_base_auth var naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ You can find a more complete example that uses this module but also includes set
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_list_cidr_blocks"></a> [access\_list\_cidr\_blocks](#input\_access\_list\_cidr\_blocks) | List of CIDRs we want to grant access to our Metaflow Metadata Service. Usually this is our VPN's CIDR blocks. | `list(string)` | `[]` | no |
-| <a name="input_api_basic_auth"></a> [api\_basic\_auth](#input\_api\_basic\_auth) | Enable basic auth for API Gateway? (requires key export) | `bool` | `true` | no |
 | <a name="input_batch_type"></a> [batch\_type](#input\_batch\_type) | AWS Batch Compute Type ('ec2', 'fargate') | `string` | `"ec2"` | no |
 | <a name="input_compute_environment_desired_vcpus"></a> [compute\_environment\_desired\_vcpus](#input\_compute\_environment\_desired\_vcpus) | Desired Starting VCPUs for Batch Compute Environment [0-16] for EC2 Batch Compute Environment (ignored for Fargate) | `number` | `8` | no |
 | <a name="input_compute_environment_egress_cidr_blocks"></a> [compute\_environment\_egress\_cidr\_blocks](#input\_compute\_environment\_egress\_cidr\_blocks) | CIDR blocks to which egress is allowed from the Batch Compute environment's security group | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
@@ -112,6 +111,8 @@ You can find a more complete example that uses this module but also includes set
 | <a name="input_launch_template_http_put_response_hop_limit"></a> [launch\_template\_http\_put\_response\_hop\_limit](#input\_launch\_template\_http\_put\_response\_hop\_limit) | The desired HTTP PUT response hop limit for instance metadata requests. Can be an integer from 1 to 64 | `number` | `2` | no |
 | <a name="input_launch_template_http_tokens"></a> [launch\_template\_http\_tokens](#input\_launch\_template\_http\_tokens) | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be 'optional' or 'required' | `string` | `"optional"` | no |
 | <a name="input_metadata_service_container_image"></a> [metadata\_service\_container\_image](#input\_metadata\_service\_container\_image) | Container image for metadata service | `string` | `""` | no |
+| <a name="input_metadata_service_enable_api_basic_auth"></a> [metadata\_service\_enable\_api\_basic\_auth](#input\_metadata\_service\_enable\_api\_basic\_auth) | Enable basic auth for API Gateway? (requires key export) | `bool` | `true` | no |
+| <a name="input_metadata_service_enable_api_gateway"></a> [metadata\_service\_enable\_api\_gateway](#input\_metadata\_service\_enable\_api\_gateway) | Enable API Gateway for public metadata service endpoint | `bool` | `true` | no |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | string prefix for all resources | `string` | `"metaflow"` | no |
 | <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | string suffix for all resources | `string` | `""` | no |
 | <a name="input_subnet1_id"></a> [subnet1\_id](#input\_subnet1\_id) | First subnet used for availability zone redundancy | `string` | n/a | yes |

--- a/examples/eks_airflow/metaflow.tf
+++ b/examples/eks_airflow/metaflow.tf
@@ -48,11 +48,12 @@ module "metaflow-metadata-service" {
   resource_suffix = local.resource_suffix
 
   access_list_cidr_blocks          = []
-  api_basic_auth                   = true
   database_name                    = module.metaflow-datastore.database_name
   database_password                = module.metaflow-datastore.database_password
   database_username                = module.metaflow-datastore.database_username
   datastore_s3_bucket_kms_key_arn  = module.metaflow-datastore.datastore_s3_bucket_kms_key_arn
+  enable_api_basic_auth            = true
+  enable_api_gateway               = true
   fargate_execution_role_arn       = aws_iam_role.ecs_execution_role.arn
   metaflow_vpc_id                  = module.vpc.vpc_id
   metadata_service_container_image = module.metaflow-common.default_metadata_service_container_image

--- a/main.tf
+++ b/main.tf
@@ -19,11 +19,12 @@ module "metaflow-metadata-service" {
   resource_suffix = local.resource_suffix
 
   access_list_cidr_blocks          = var.access_list_cidr_blocks
-  api_basic_auth                   = var.api_basic_auth
   database_name                    = module.metaflow-datastore.database_name
   database_password                = module.metaflow-datastore.database_password
   database_username                = module.metaflow-datastore.database_username
   datastore_s3_bucket_kms_key_arn  = module.metaflow-datastore.datastore_s3_bucket_kms_key_arn
+  enable_api_basic_auth            = var.metadata_service_enable_api_basic_auth
+  enable_api_gateway               = var.metadata_service_enable_api_gateway
   fargate_execution_role_arn       = module.metaflow-computation.ecs_execution_role_arn
   iam_partition                    = var.iam_partition
   metadata_service_container_image = local.metadata_service_container_image

--- a/modules/metadata-service/README.md
+++ b/modules/metadata-service/README.md
@@ -16,11 +16,12 @@ If the `access_list_cidr_blocks` variable is set, only traffic originating from 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_list_cidr_blocks"></a> [access\_list\_cidr\_blocks](#input\_access\_list\_cidr\_blocks) | List of CIDRs we want to grant access to our Metaflow Metadata Service. Usually this is our VPN's CIDR blocks. | `list(string)` | n/a | yes |
-| <a name="input_api_basic_auth"></a> [api\_basic\_auth](#input\_api\_basic\_auth) | Enable basic auth for API Gateway? (requires key export) | `bool` | `true` | no |
 | <a name="input_database_name"></a> [database\_name](#input\_database\_name) | The database name | `string` | `"metaflow"` | no |
 | <a name="input_database_password"></a> [database\_password](#input\_database\_password) | The database password | `string` | n/a | yes |
 | <a name="input_database_username"></a> [database\_username](#input\_database\_username) | The database username | `string` | n/a | yes |
 | <a name="input_datastore_s3_bucket_kms_key_arn"></a> [datastore\_s3\_bucket\_kms\_key\_arn](#input\_datastore\_s3\_bucket\_kms\_key\_arn) | The ARN of the KMS key used to encrypt the Metaflow datastore S3 bucket | `string` | n/a | yes |
+| <a name="input_enable_api_basic_auth"></a> [enable\_api\_basic\_auth](#input\_enable\_api\_basic\_auth) | Enable basic auth for API Gateway? (requires key export) | `bool` | `true` | no |
+| <a name="input_enable_api_gateway"></a> [enable\_api\_gateway](#input\_enable\_api\_gateway) | Enable API Gateway for public metadata service endpoint | `bool` | `true` | no |
 | <a name="input_fargate_execution_role_arn"></a> [fargate\_execution\_role\_arn](#input\_fargate\_execution\_role\_arn) | The IAM role that grants access to ECS and Batch services which we'll use as our Metadata Service API's execution\_role for our Fargate instance | `string` | n/a | yes |
 | <a name="input_iam_partition"></a> [iam\_partition](#input\_iam\_partition) | IAM Partition (Select aws-us-gov for AWS GovCloud, otherwise leave as is) | `string` | `"aws"` | no |
 | <a name="input_is_gov"></a> [is\_gov](#input\_is\_gov) | Set to true if IAM partition is 'aws-us-gov' | `bool` | `false` | no |

--- a/modules/metadata-service/api-gateway.tf
+++ b/modules/metadata-service/api-gateway.tf
@@ -62,7 +62,7 @@ resource "aws_api_gateway_vpc_link" "this" {
 }
 
 resource "aws_api_gateway_method" "this" {
-  count       = var.enable_api_gateway ? 1 : 0
+  count            = var.enable_api_gateway ? 1 : 0
   http_method      = "ANY"
   resource_id      = aws_api_gateway_resource.this[0].id
   rest_api_id      = aws_api_gateway_rest_api.this[0].id
@@ -75,7 +75,7 @@ resource "aws_api_gateway_method" "this" {
 }
 
 resource "aws_api_gateway_method" "db" {
-  count       = var.enable_api_gateway ? 1 : 0
+  count            = var.enable_api_gateway ? 1 : 0
   http_method      = "GET"
   resource_id      = aws_api_gateway_resource.db[0].id
   rest_api_id      = aws_api_gateway_rest_api.this[0].id
@@ -159,7 +159,7 @@ resource "aws_api_gateway_deployment" "this" {
 }
 
 resource "aws_api_gateway_stage" "this" {
-  count       = var.enable_api_gateway ? 1 : 0
+  count         = var.enable_api_gateway ? 1 : 0
   deployment_id = aws_api_gateway_deployment.this[0].id
   rest_api_id   = aws_api_gateway_rest_api.this[0].id
   stage_name    = local.api_gateway_stage_name

--- a/modules/metadata-service/outputs.tf
+++ b/modules/metadata-service/outputs.tf
@@ -4,12 +4,12 @@ output "METAFLOW_SERVICE_INTERNAL_URL" {
 }
 
 output "METAFLOW_SERVICE_URL" {
-  value       = "https://${aws_api_gateway_rest_api.this.id}.execute-api.${data.aws_region.current.name}.amazonaws.com/api/"
+  value       = var.enable_api_gateway ? "https://${aws_api_gateway_rest_api.this[0].id}.execute-api.${data.aws_region.current.name}.amazonaws.com/api/" : ""
   description = "URL for Metadata Service (Open to Public Access)"
 }
 
 output "api_gateway_rest_api_id" {
-  value       = aws_api_gateway_rest_api.this.id
+  value       = var.enable_api_gateway ? aws_api_gateway_rest_api.this[0].id : ""
   description = "The ID of the API Gateway REST API we'll use to accept MetaData service requests to forward to the Fargate API instance"
 }
 

--- a/modules/metadata-service/variables.tf
+++ b/modules/metadata-service/variables.tf
@@ -3,11 +3,6 @@ variable "access_list_cidr_blocks" {
   description = "List of CIDRs we want to grant access to our Metaflow Metadata Service. Usually this is our VPN's CIDR blocks."
 }
 
-variable "api_basic_auth" {
-  type        = bool
-  default     = true
-  description = "Enable basic auth for API Gateway? (requires key export)"
-}
 
 variable "database_name" {
   type        = string
@@ -28,6 +23,18 @@ variable "database_username" {
 variable "datastore_s3_bucket_kms_key_arn" {
   type        = string
   description = "The ARN of the KMS key used to encrypt the Metaflow datastore S3 bucket"
+}
+
+variable "enable_api_basic_auth" {
+  type        = bool
+  default     = true
+  description = "Enable basic auth for API Gateway? (requires key export)"
+}
+
+variable "enable_api_gateway" {
+  type        = bool
+  default     = true
+  description = "Enable API Gateway for public metadata service endpoint"
 }
 
 variable "fargate_execution_role_arn" {
@@ -104,7 +111,6 @@ variable "subnet2_id" {
   type        = string
   description = "Second private subnet used for availability zone redundancy"
 }
-
 variable "vpc_cidr_blocks" {
   type        = list(string)
   description = "The VPC CIDR blocks that we'll access list on our Metadata Service API to allow all internal communications"

--- a/outputs.tf
+++ b/outputs.tf
@@ -74,7 +74,7 @@ output "metaflow_profile_json" {
         "METAFLOW_BATCH_CONTAINER_REGISTRY" = element(split("/", aws_ecr_repository.metaflow_batch_image[0].repository_url), 0),
         "METAFLOW_BATCH_CONTAINER_IMAGE"    = element(split("/", aws_ecr_repository.metaflow_batch_image[0].repository_url), 1)
       } : {},
-      var.api_basic_auth ? {
+      var.enable_api_basic_auth ? {
         "METAFLOW_SERVICE_AUTH_KEY" = "## Replace with output from 'aws apigateway get-api-key --api-key ${module.metaflow-metadata-service.api_gateway_rest_api_id_key_id} --include-value | grep value' ##"
       } : {},
       var.batch_type == "fargate" ? {

--- a/outputs.tf
+++ b/outputs.tf
@@ -74,7 +74,7 @@ output "metaflow_profile_json" {
         "METAFLOW_BATCH_CONTAINER_REGISTRY" = element(split("/", aws_ecr_repository.metaflow_batch_image[0].repository_url), 0),
         "METAFLOW_BATCH_CONTAINER_IMAGE"    = element(split("/", aws_ecr_repository.metaflow_batch_image[0].repository_url), 1)
       } : {},
-      var.enable_api_basic_auth ? {
+      var.metadata_service_enable_api_basic_auth ? {
         "METAFLOW_SERVICE_AUTH_KEY" = "## Replace with output from 'aws apigateway get-api-key --api-key ${module.metaflow-metadata-service.api_gateway_rest_api_id_key_id} --include-value | grep value' ##"
       } : {},
       var.batch_type == "fargate" ? {

--- a/variables.tf
+++ b/variables.tf
@@ -4,12 +4,6 @@ variable "access_list_cidr_blocks" {
   default     = []
 }
 
-variable "api_basic_auth" {
-  type        = bool
-  default     = true
-  description = "Enable basic auth for API Gateway? (requires key export)"
-}
-
 variable "batch_type" {
   type        = string
   description = "AWS Batch Compute Type ('ec2', 'fargate')"
@@ -95,6 +89,18 @@ variable "metadata_service_container_image" {
   type        = string
   default     = ""
   description = "Container image for metadata service"
+}
+
+variable "metadata_service_enable_api_basic_auth" {
+  type        = bool
+  default     = true
+  description = "Enable basic auth for API Gateway? (requires key export)"
+}
+
+variable "metadata_service_enable_api_gateway" {
+  type        = bool
+  default     = true
+  description = "Enable API Gateway for public metadata service endpoint"
 }
 
 variable "ui_static_container_image" {


### PR DESCRIPTION
Addresses issue https://github.com/outerbounds/terraform-aws-metaflow/issues/22

In production environments, some teams will not want to use public-facing API Gateway resources. This PR makes API Gateway optional by adding a var to the metadata service `enable_api_gateway`. I also adjusted the `api_basic_auth` var to use the `enable_` prefix, in keeping with the bool var naming in this repo.