### PR TITLE
Fix port for metadata service ec2 security group health check

### DIFF
--- a/modules/metadata-service/ec2.tf
+++ b/modules/metadata-service/ec2.tf
@@ -79,7 +79,7 @@ resource "aws_lb_target_group" "db_migrate" {
 
   health_check {
     protocol            = "TCP"
-    port                = 8080
+    port                = 8082
     interval            = 10
     healthy_threshold   = 2
     unhealthy_threshold = 2


### PR DESCRIPTION
The health check port for the `resource "aws_lb_target_group" "db_migrate"`  was set to 8080, but the migration service runs on 8082. Adjust the health check.

Slack thread here: https://outerbounds-community.slack.com/archives/C020U025QJK/p1663011907609479