### PR TITLE
Add custom output path for the DB migrate lambda

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,7 @@ module "metaflow-metadata-service" {
   database_name                    = module.metaflow-datastore.database_name
   database_password                = module.metaflow-datastore.database_password
   database_username                = module.metaflow-datastore.database_username
+  db_migrate_lambda_zip_file       = var.db_migrate_lambda_zip_file
   datastore_s3_bucket_kms_key_arn  = module.metaflow-datastore.datastore_s3_bucket_kms_key_arn
   fargate_execution_role_arn       = module.metaflow-computation.ecs_execution_role_arn
   iam_partition                    = var.iam_partition

--- a/modules/metadata-service/lambda.tf
+++ b/modules/metadata-service/lambda.tf
@@ -78,8 +78,13 @@ resource "aws_iam_role_policy" "grant_lambda_ecs_vpc" {
   policy = data.aws_iam_policy_document.lambda_ecs_task_execute_policy_vpc.json
 }
 
-resource "local_file" "db_migrate_lambda" {
-  content  = <<EOF
+data "archive_file" "db_migrate_lambda" {
+  type             = "zip"
+  output_file_mode = "0666"
+  output_path      = local.db_migrate_lambda_zip_file
+
+  source {
+    content  = <<EOF
 import os, json
 from urllib import request
 
@@ -101,15 +106,8 @@ def handler(event, context):
   print(response)
   return(response)
 EOF
-  filename = local.db_migrate_lambda_source_file
-}
-
-data "archive_file" "db_migrate_lambda" {
-  type             = "zip"
-  source_file      = local.db_migrate_lambda_source_file
-  output_file_mode = "0666"
-  output_path      = local.db_migrate_lambda_zip_file
-  depends_on       = [local_file.db_migrate_lambda]
+    filename = "index.py"
+  }
 }
 
 resource "aws_lambda_function" "db_migrate_lambda" {

--- a/modules/metadata-service/locals.tf
+++ b/modules/metadata-service/locals.tf
@@ -22,10 +22,9 @@ locals {
   api_gateway_stage_name                  = "api"
   api_gateway_usage_plan_name             = "${var.resource_prefix}usage-plan${var.resource_suffix}"
 
-  db_migrate_lambda_source_file = "${path.module}/index.py"
-  db_migrate_lambda_zip_file    = "${path.module}/db_migrate_lambda.zip"
-  db_migrate_lambda_name        = "${var.resource_prefix}db_migrate${var.resource_suffix}"
-  lambda_ecs_execute_role_name  = "${var.resource_prefix}lambda_ecs_execute${var.resource_suffix}"
+  db_migrate_lambda_zip_file   = "${path.module}/db_migrate_lambda.zip"
+  db_migrate_lambda_name       = "${var.resource_prefix}db_migrate${var.resource_suffix}"
+  lambda_ecs_execute_role_name = "${var.resource_prefix}lambda_ecs_execute${var.resource_suffix}"
 
   cloudwatch_logs_arn_prefix = "arn:${var.iam_partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}"
 }

--- a/modules/metadata-service/locals.tf
+++ b/modules/metadata-service/locals.tf
@@ -22,7 +22,7 @@ locals {
   api_gateway_stage_name                  = "api"
   api_gateway_usage_plan_name             = "${var.resource_prefix}usage-plan${var.resource_suffix}"
 
-  db_migrate_lambda_zip_file   = "${path.module}/db_migrate_lambda.zip"
+  db_migrate_lambda_zip_file   = coalesce(var.db_migrate_lambda_zip_file, "${path.module}/db_migrate_lambda.zip")
   db_migrate_lambda_name       = "${var.resource_prefix}db_migrate${var.resource_suffix}"
   lambda_ecs_execute_role_name = "${var.resource_prefix}lambda_ecs_execute${var.resource_suffix}"
 

--- a/modules/metadata-service/variables.tf
+++ b/modules/metadata-service/variables.tf
@@ -30,6 +30,12 @@ variable "datastore_s3_bucket_kms_key_arn" {
   description = "The ARN of the KMS key used to encrypt the Metaflow datastore S3 bucket"
 }
 
+variable "db_migrate_lambda_zip_file" {
+  type        = string
+  description = "Output path for the zip file containing the DB migrate lambda"
+  default     = null
+}
+
 variable "fargate_execution_role_arn" {
   type        = string
   description = "The IAM role that grants access to ECS and Batch services which we'll use as our Metadata Service API's execution_role for our Fargate instance"

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "batch_type" {
   default     = "ec2"
 }
 
+variable "db_migrate_lambda_zip_file" {
+  type        = string
+  description = "Output path for the zip file containing the DB migrate lambda"
+  default     = null
+}
+
 variable "enable_custom_batch_container_registry" {
   type        = bool
   default     = false


### PR DESCRIPTION
We had a problem where we were seeing Terraform config [drift](https://github.com/dflook/terraform-github-actions/#checking-for-drift) and unstable plans because the `db_migrate_lambda.zip` file was being written inside the terraform module folder, which can be _outside_ the repo folder (e.g. if `TF_DATA_DIR` is set). That means there is no zip file (or `index.py`) available to a fresh `plan` and so TF detects a deletion.

A solution to this is to commit or to cache the zip file across builds, but this TF module does not allow that location to be customised.

This PR makes two changes:

1. The contents of the migrate lambda Python file are now inlined, which makes for one fewer files to manage
2. There's a variable that specifies the output location so it can be written to the repo/cache location

To test this:

* I linked the repo that is using this module to our remote branch and verified that the plan became stable and nothing else changes
* I checked the contents of the zip file to verify it still contained a single index.py file
* I did _not_ verify the lambda behaviour (not sure how; happy to try)