### PR TITLE
Add engine_version in main for data-store module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ module "metaflow-datastore" {
   resource_prefix = local.resource_prefix
   resource_suffix = local.resource_suffix
 
+  db_engine_version                  = var.db_engine_version
   metadata_service_security_group_id = module.metaflow-metadata-service.metadata_service_security_group_id
   metaflow_vpc_id                    = var.vpc_id
   subnet1_id                         = var.subnet1_id

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "batch_type" {
   default     = "ec2"
 }
 
+variable "db_engine_version" {
+  type        = string
+  default     = "11"
+  description = "engine version for metaflow module data-store"
+}
+
 variable "enable_custom_batch_container_registry" {
   type        = bool
   default     = false


### PR DESCRIPTION
Expose the variable db_engine_version in main to select the engin version for the database in the module and allow updating it.