### PR TITLE
Update docs and remove the default for with_public_ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You can find a more complete example that uses this module but also includes set
 | <a name="input_ui_static_container_image"></a> [ui\_static\_container\_image](#input\_ui\_static\_container\_image) | Container image for the UI frontend app | `string` | `""` | no |
 | <a name="input_vpc_cidr_blocks"></a> [vpc\_cidr\_blocks](#input\_vpc\_cidr\_blocks) | The VPC CIDR blocks that we'll access list on our Metadata Service API to allow all internal communications | `list(string)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The id of the single VPC we stood up for all Metaflow resources to exist in. | `string` | n/a | yes |
-| <a name="input_with_public_ip"></a> [with\_public\_ip](#input\_with\_public\_ip) | Enable public IP assignment for the Metadata Service. Typically you want this to be set to true if using public subnets as subnet1\_id and subnet2\_id, and false otherwise | `bool` | `false` | no |
+| <a name="input_with_public_ip"></a> [with\_public\_ip](#input\_with\_public\_ip) | Enable public IP assignment for the Metadata Service. Typically you want this to be set to true if using public subnets as subnet1\_id and subnet2\_id, and false otherwise | `bool` | n/a | yes |
 
 ## Outputs
 

--- a/examples/minimal/minimal_example.tf
+++ b/examples/minimal/minimal_example.tf
@@ -38,7 +38,7 @@ module "vpc" {
 
 module "metaflow" {
   source  = "outerbounds/metaflow/aws"
-  version = "0.8.0"
+  version = "0.9.0"
 
   resource_prefix = local.resource_prefix
   resource_suffix = local.resource_suffix
@@ -48,7 +48,7 @@ module "metaflow" {
   subnet2_id            = module.vpc.public_subnets[1]
   vpc_cidr_blocks       = [module.vpc.vpc_cidr_block]
   vpc_id                = module.vpc.vpc_id
-  with_public_ip        = var.with_public_ip
+  with_public_ip        = true
 
   tags = {
     "managedBy" = "terraform"

--- a/modules/metadata-service/README.md
+++ b/modules/metadata-service/README.md
@@ -37,7 +37,7 @@ If the `access_list_cidr_blocks` variable is set, only traffic originating from 
 | <a name="input_subnet1_id"></a> [subnet1\_id](#input\_subnet1\_id) | First private subnet used for availability zone redundancy | `string` | n/a | yes |
 | <a name="input_subnet2_id"></a> [subnet2\_id](#input\_subnet2\_id) | Second private subnet used for availability zone redundancy | `string` | n/a | yes |
 | <a name="input_vpc_cidr_blocks"></a> [vpc\_cidr\_blocks](#input\_vpc\_cidr\_blocks) | The VPC CIDR blocks that we'll access list on our Metadata Service API to allow all internal communications | `list(string)` | n/a | yes |
-| <a name="input_with_public_ip"></a> [with\_public\_ip](#input\_with\_public\_ip) | Enable public IP assignment for the Metadata Service. Typically you want this to be set to true if using public subnets as subnet1\_id and subnet2\_id, and false otherwise | `bool` | `false` | no |
+| <a name="input_with_public_ip"></a> [with\_public\_ip](#input\_with\_public\_ip) | Enable public IP assignment for the Metadata Service. Typically you want this to be set to true if using public subnets as subnet1\_id and subnet2\_id, and false otherwise | `bool` | n/a | yes |
 
 ## Outputs
 

--- a/modules/metadata-service/variables.tf
+++ b/modules/metadata-service/variables.tf
@@ -118,6 +118,5 @@ variable "vpc_cidr_blocks" {
 
 variable "with_public_ip" {
   type        = bool
-  default     = false
   description = "Enable public IP assignment for the Metadata Service. Typically you want this to be set to true if using public subnets as subnet1_id and subnet2_id, and false otherwise"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -168,6 +168,5 @@ variable "extra_ui_static_env_vars" {
 
 variable "with_public_ip" {
   type        = bool
-  default     = false
   description = "Enable public IP assignment for the Metadata Service. Typically you want this to be set to true if using public subnets as subnet1_id and subnet2_id, and false otherwise"
 }


### PR DESCRIPTION
The reasonable default value for this flag depends on whether subnets are public or not, so its arguably better to make users set it explicitly. 

https://github.com/outerbounds/terraform-aws-metaflow/pull/42#issuecomment-1329980605