### PR TITLE
Move database migration script to a dedicated file

### DIFF
--- a/modules/metadata-service/.gitignore
+++ b/modules/metadata-service/.gitignore
@@ -1,2 +1,1 @@
-index.py
 db_migrate_lambda.zip

--- a/modules/metadata-service/db_migrate/index.py
+++ b/modules/metadata-service/db_migrate/index.py
@@ -1,0 +1,20 @@
+import os, json
+from urllib import request
+
+def handler(event, context):
+  response = {}
+  status_endpoint = "{}/db_schema_status".format(os.environ.get('MD_LB_ADDRESS'))
+  upgrade_endpoint = "{}/upgrade".format(os.environ.get('MD_LB_ADDRESS'))
+
+  with request.urlopen(status_endpoint) as status:
+    response['init-status'] = json.loads(status.read())
+
+  upgrade_patch = request.Request(upgrade_endpoint, method='PATCH')
+  with request.urlopen(upgrade_patch) as upgrade:
+    response['upgrade-result'] = upgrade.read().decode()
+
+  with request.urlopen(status_endpoint) as status:
+    response['final-status'] = json.loads(status.read())
+
+  print(response)
+  return(response)

--- a/modules/metadata-service/lambda.tf
+++ b/modules/metadata-service/lambda.tf
@@ -78,38 +78,11 @@ resource "aws_iam_role_policy" "grant_lambda_ecs_vpc" {
   policy = data.aws_iam_policy_document.lambda_ecs_task_execute_policy_vpc.json
 }
 
-resource "local_file" "db_migrate_lambda" {
-  content  = <<EOF
-import os, json
-from urllib import request
-
-def handler(event, context):
-  response = {}
-  status_endpoint = "{}/db_schema_status".format(os.environ.get('MD_LB_ADDRESS'))
-  upgrade_endpoint = "{}/upgrade".format(os.environ.get('MD_LB_ADDRESS'))
-
-  with request.urlopen(status_endpoint) as status:
-    response['init-status'] = json.loads(status.read())
-
-  upgrade_patch = request.Request(upgrade_endpoint, method='PATCH')
-  with request.urlopen(upgrade_patch) as upgrade:
-    response['upgrade-result'] = upgrade.read().decode()
-
-  with request.urlopen(status_endpoint) as status:
-    response['final-status'] = json.loads(status.read())
-
-  print(response)
-  return(response)
-EOF
-  filename = local.db_migrate_lambda_source_file
-}
-
 data "archive_file" "db_migrate_lambda" {
   type             = "zip"
   source_file      = local.db_migrate_lambda_source_file
   output_file_mode = "0666"
   output_path      = local.db_migrate_lambda_zip_file
-  depends_on       = [local_file.db_migrate_lambda]
 }
 
 resource "aws_lambda_function" "db_migrate_lambda" {

--- a/modules/metadata-service/locals.tf
+++ b/modules/metadata-service/locals.tf
@@ -22,7 +22,7 @@ locals {
   api_gateway_stage_name                  = "api"
   api_gateway_usage_plan_name             = "${var.resource_prefix}usage-plan${var.resource_suffix}"
 
-  db_migrate_lambda_source_file = "${path.module}/index.py"
+  db_migrate_lambda_source_file = "${path.module}/db_migrate/index.py"
   db_migrate_lambda_zip_file    = "${path.module}/db_migrate_lambda.zip"
   db_migrate_lambda_name        = "${var.resource_prefix}db_migrate${var.resource_suffix}"
   lambda_ecs_execute_role_name  = "${var.resource_prefix}lambda_ecs_execute${var.resource_suffix}"


### PR DESCRIPTION
Hi!

Currently, every plan (in a CI/CD run) for this module results in update even though the Terraform code hasn’t changed. This is because of the `index.py` migration script being generated from tf. Moving this script to a file resolve this problem.

```
<= data "archive_file" "db_migrate_lambda" {
      + id                  = (known after apply)
      + output_base64sha256 = (known after apply)
      + output_file_mode    = "0666"
      + output_md5          = (known after apply)
      + output_path         = ".terraform/modules/metaflow/modules/metadata-service/db_migrate_lambda.zip"
      + output_sha          = (known after apply)
      + output_size         = (known after apply)
      + source_file         = ".terraform/modules/metaflow/modules/metadata-service/index.py"
      + type                = "zip"
    }

  # module.metaflow.module.metaflow-metadata-service.aws_lambda_function.db_migrate_lambda will be updated in-place
  ~ resource "aws_lambda_function" "db_migrate_lambda" {
  ```