### PR TITLE
IOPS=3000, ebs-optimized and gp3 volumes

### DIFF
--- a/modules/computation/ec2.tf
+++ b/modules/computation/ec2.tf
@@ -22,8 +22,11 @@ resource "aws_launch_template" "cpu" {
       volume_size           = 100
       delete_on_termination = true
       encrypted             = true
+      iops                  = 1000
+      volume_type           = "gp3"
     }
   }
+  ebs_optimized = true
 
   metadata_options {
     http_endpoint               = var.launch_template_http_endpoint


### PR DESCRIPTION
The default launch template used by metaflow seems to provision gp2 volumes with 300 IOPS. The EC2 instances spawned are also not EBS-optimized (see below). All of these might limit performance for our use cases (heavy S3 to disk traffic) and might contribute to CannotInspectContainerErrors when multiple IO-heavy tasks are spawned on the same EC2 instance. 
This PR sets IOPS provisioning to 3000, turns on ebs optimization for instances and uses gp3 instead of gp2 volumes.

Amazon charge $0.072 per IOPS/month, which means 3000 IOPS would translate to a cost of $216 per month if an average of 1 instance is on 24/7 (we are most likely far below that).


![image](https://github.com/outerbounds/terraform-aws-metaflow/assets/116085383/78df5ae7-5e16-4a3d-a309-59ff9b5fe7b6)

<img width="1189" alt="image" src="https://github.com/outerbounds/terraform-aws-metaflow/assets/116085383/4d9b21f3-10f9-46ef-8730-25fda38eeb86">

