### PR TITLE
Add option to enable KMS key rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ resource "local_file" "metaflow_config" {
 | <a name="input_db_instance_type"></a> [db\_instance\_type](#input\_db\_instance\_type) | RDS instance type to launch for PostgresQL database. | `string` | `"db.t2.small"` | no |
 | <a name="input_db_migrate_lambda_zip_file"></a> [db\_migrate\_lambda\_zip\_file](#input\_db\_migrate\_lambda\_zip\_file) | Output path for the zip file containing the DB migrate lambda | `string` | `null` | no |
 | <a name="input_enable_custom_batch_container_registry"></a> [enable\_custom\_batch\_container\_registry](#input\_enable\_custom\_batch\_container\_registry) | Provisions infrastructure for custom Amazon ECR container registry if enabled | `bool` | `false` | no |
+| <a name="input_enable_key_rotation"></a> [enable\_key\_rotation](#input\_enable\_key\_rotation) | Enable key rotation for KMS keys | `bool` | `false` | no |
 | <a name="input_enable_step_functions"></a> [enable\_step\_functions](#input\_enable\_step\_functions) | Provisions infrastructure for step functions if enabled | `bool` | n/a | yes |
 | <a name="input_extra_ui_backend_env_vars"></a> [extra\_ui\_backend\_env\_vars](#input\_extra\_ui\_backend\_env\_vars) | Additional environment variables for UI backend container | `map(string)` | `{}` | no |
 | <a name="input_extra_ui_static_env_vars"></a> [extra\_ui\_static\_env\_vars](#input\_extra\_ui\_static\_env\_vars) | Additional environment variables for UI static app | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@ module "metaflow-datastore" {
   source = "./modules/datastore"
 
   force_destroy_s3_bucket = var.force_destroy_s3_bucket
+  enable_key_rotation     = var.enable_key_rotation
 
   resource_prefix = local.resource_prefix
   resource_suffix = local.resource_suffix

--- a/modules/datastore/README.md
+++ b/modules/datastore/README.md
@@ -24,6 +24,7 @@ To read more, see [the Metaflow docs](https://docs.metaflow.org/metaflow-on-aws/
 | <a name="input_db_instance_type"></a> [db\_instance\_type](#input\_db\_instance\_type) | RDS instance type to launch for PostgresQL database. | `string` | `"db.t3.small"` | no |
 | <a name="input_db_name"></a> [db\_name](#input\_db\_name) | Name of PostgresQL database for Metaflow service. | `string` | `"metaflow"` | no |
 | <a name="input_db_username"></a> [db\_username](#input\_db\_username) | PostgresQL username; defaults to 'metaflow' | `string` | `"metaflow"` | no |
+| <a name="input_enable_key_rotation"></a> [enable\_key\_rotation](#input\_enable\_key\_rotation) | Enable key rotation for KMS keys | `bool` | `false` | no |
 | <a name="input_force_destroy_s3_bucket"></a> [force\_destroy\_s3\_bucket](#input\_force\_destroy\_s3\_bucket) | Empty S3 bucket before destroying via terraform destroy | `bool` | `false` | no |
 | <a name="input_metadata_service_security_group_id"></a> [metadata\_service\_security\_group\_id](#input\_metadata\_service\_security\_group\_id) | The security group ID used by the MetaData service. We'll grant this access to our DB. | `string` | n/a | yes |
 | <a name="input_metaflow_vpc_id"></a> [metaflow\_vpc\_id](#input\_metaflow\_vpc\_id) | ID of the Metaflow VPC this SageMaker notebook instance is to be deployed in | `string` | n/a | yes |

--- a/modules/datastore/kms.tf
+++ b/modules/datastore/kms.tf
@@ -1,11 +1,13 @@
 resource "aws_kms_key" "s3" {
-  description = "This key is used to encrypt and decrypt the S3 bucket used to store blobs."
+  description         = "This key is used to encrypt and decrypt the S3 bucket used to store blobs."
+  enable_key_rotation = var.enable_key_rotation
 
   tags = var.standard_tags
 }
 
 resource "aws_kms_key" "rds" {
-  description = "This key is used to encrypt and decrypt the RDS database used to store flow execution data."
+  description         = "This key is used to encrypt and decrypt the RDS database used to store flow execution data."
+  enable_key_rotation = var.enable_key_rotation
 
   tags = var.standard_tags
 }

--- a/modules/datastore/variables.tf
+++ b/modules/datastore/variables.tf
@@ -65,3 +65,9 @@ variable "subnet2_id" {
   type        = string
   description = "Second subnet used for availability zone redundancy"
 }
+
+variable "enable_key_rotation" {
+  type        = bool
+  description = "Enable key rotation for KMS keys"
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -193,3 +193,9 @@ variable "force_destroy_s3_bucket" {
   description = "Empty S3 bucket before destroying via terraform destroy"
   default     = false
 }
+
+variable "enable_key_rotation" {
+  type        = bool
+  description = "Enable key rotation for KMS keys"
+  default     = false
+}


### PR DESCRIPTION
This PR adds the option to enable KMS key rotation for the keys that Metaflow creates. There are two keys created and both are in the datastore module.

The option defaults to false, because [key rotation does incur a slight cost](https://aws.amazon.com/kms/pricing/). It is a very small cost ($1 per iteration of a key), but a cost nonetheless. 