### PR TITLE
Add variable for ephemeral_storage in metadata-service aws_ecs_task_definition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,24 +23,25 @@ module "metaflow-metadata-service" {
   resource_prefix = local.resource_prefix
   resource_suffix = local.resource_suffix
 
-  access_list_cidr_blocks          = var.access_list_cidr_blocks
-  database_name                    = module.metaflow-datastore.database_name
-  database_password                = module.metaflow-datastore.database_password
-  database_username                = module.metaflow-datastore.database_username
-  db_migrate_lambda_zip_file       = var.db_migrate_lambda_zip_file
-  datastore_s3_bucket_kms_key_arn  = module.metaflow-datastore.datastore_s3_bucket_kms_key_arn
-  enable_api_basic_auth            = var.metadata_service_enable_api_basic_auth
-  enable_api_gateway               = var.metadata_service_enable_api_gateway
-  fargate_execution_role_arn       = module.metaflow-computation.ecs_execution_role_arn
-  iam_partition                    = var.iam_partition
-  metadata_service_container_image = local.metadata_service_container_image
-  metaflow_vpc_id                  = var.vpc_id
-  rds_master_instance_endpoint     = module.metaflow-datastore.rds_master_instance_endpoint
-  s3_bucket_arn                    = module.metaflow-datastore.s3_bucket_arn
-  subnet1_id                       = var.subnet1_id
-  subnet2_id                       = var.subnet2_id
-  vpc_cidr_blocks                  = var.vpc_cidr_blocks
-  with_public_ip                   = var.with_public_ip
+  access_list_cidr_blocks           = var.access_list_cidr_blocks
+  database_name                     = module.metaflow-datastore.database_name
+  database_password                 = module.metaflow-datastore.database_password
+  database_username                 = module.metaflow-datastore.database_username
+  db_migrate_lambda_zip_file        = var.db_migrate_lambda_zip_file
+  datastore_s3_bucket_kms_key_arn   = module.metaflow-datastore.datastore_s3_bucket_kms_key_arn
+  enable_api_basic_auth             = var.metadata_service_enable_api_basic_auth
+  enable_api_gateway                = var.metadata_service_enable_api_gateway
+  fargate_execution_role_arn        = module.metaflow-computation.ecs_execution_role_arn
+  iam_partition                     = var.iam_partition
+  metadata_service_container_image  = local.metadata_service_container_image
+  metadata_serviceephemeral_storage = var.metadata_service_ephemeral_storage
+  metaflow_vpc_id                   = var.vpc_id
+  rds_master_instance_endpoint      = module.metaflow-datastore.rds_master_instance_endpoint
+  s3_bucket_arn                     = module.metaflow-datastore.s3_bucket_arn
+  subnet1_id                        = var.subnet1_id
+  subnet2_id                        = var.subnet2_id
+  vpc_cidr_blocks                   = var.vpc_cidr_blocks
+  with_public_ip                    = var.with_public_ip
 
   standard_tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -23,25 +23,25 @@ module "metaflow-metadata-service" {
   resource_prefix = local.resource_prefix
   resource_suffix = local.resource_suffix
 
-  access_list_cidr_blocks           = var.access_list_cidr_blocks
-  database_name                     = module.metaflow-datastore.database_name
-  database_password                 = module.metaflow-datastore.database_password
-  database_username                 = module.metaflow-datastore.database_username
-  db_migrate_lambda_zip_file        = var.db_migrate_lambda_zip_file
-  datastore_s3_bucket_kms_key_arn   = module.metaflow-datastore.datastore_s3_bucket_kms_key_arn
-  enable_api_basic_auth             = var.metadata_service_enable_api_basic_auth
-  enable_api_gateway                = var.metadata_service_enable_api_gateway
-  fargate_execution_role_arn        = module.metaflow-computation.ecs_execution_role_arn
-  iam_partition                     = var.iam_partition
-  metadata_service_container_image  = local.metadata_service_container_image
-  metadata_serviceephemeral_storage = var.metadata_service_ephemeral_storage
-  metaflow_vpc_id                   = var.vpc_id
-  rds_master_instance_endpoint      = module.metaflow-datastore.rds_master_instance_endpoint
-  s3_bucket_arn                     = module.metaflow-datastore.s3_bucket_arn
-  subnet1_id                        = var.subnet1_id
-  subnet2_id                        = var.subnet2_id
-  vpc_cidr_blocks                   = var.vpc_cidr_blocks
-  with_public_ip                    = var.with_public_ip
+  access_list_cidr_blocks            = var.access_list_cidr_blocks
+  database_name                      = module.metaflow-datastore.database_name
+  database_password                  = module.metaflow-datastore.database_password
+  database_username                  = module.metaflow-datastore.database_username
+  db_migrate_lambda_zip_file         = var.db_migrate_lambda_zip_file
+  datastore_s3_bucket_kms_key_arn    = module.metaflow-datastore.datastore_s3_bucket_kms_key_arn
+  enable_api_basic_auth              = var.metadata_service_enable_api_basic_auth
+  enable_api_gateway                 = var.metadata_service_enable_api_gateway
+  fargate_execution_role_arn         = module.metaflow-computation.ecs_execution_role_arn
+  iam_partition                      = var.iam_partition
+  metadata_service_container_image   = local.metadata_service_container_image
+  metadata_service_ephemeral_storage = var.metadata_service_ephemeral_storage
+  metaflow_vpc_id                    = var.vpc_id
+  rds_master_instance_endpoint       = module.metaflow-datastore.rds_master_instance_endpoint
+  s3_bucket_arn                      = module.metaflow-datastore.s3_bucket_arn
+  subnet1_id                         = var.subnet1_id
+  subnet2_id                         = var.subnet2_id
+  vpc_cidr_blocks                    = var.vpc_cidr_blocks
+  with_public_ip                     = var.with_public_ip
 
   standard_tags = var.tags
 }

--- a/modules/metadata-service/ecs.tf
+++ b/modules/metadata-service/ecs.tf
@@ -56,6 +56,7 @@ EOF
   execution_role_arn       = var.fargate_execution_role_arn
   cpu                      = var.metadata_service_cpu
   memory                   = var.metadata_service_memory
+  ephemeral_storage        = var.metadata_service_ephemeral_storage
 
   tags = merge(
     var.standard_tags,

--- a/modules/metadata-service/variables.tf
+++ b/modules/metadata-service/variables.tf
@@ -78,6 +78,12 @@ variable "metadata_service_memory" {
   description = "ECS task memory in MiB for metadata service"
 }
 
+variable "metadata_service_ephemeral_storage" {
+  type        = number
+  default     = 21
+  description = "The Gb amount of disk storage to set for the ECS task [21-200]"
+}
+
 variable "metaflow_vpc_id" {
   type        = string
   description = "ID of the Metaflow VPC this SageMaker notebook instance is to be deployed in"

--- a/variables.tf
+++ b/variables.tf
@@ -108,6 +108,12 @@ variable "metadata_service_container_image" {
   description = "Container image for metadata service"
 }
 
+variable "metadata_service_ephemeral_storage" {
+  type        = number
+  default     = 21
+  description = "The Gb amount of disk storage to set for the ECS task [21-200]"
+}
+
 variable "metadata_service_enable_api_basic_auth" {
   type        = bool
   default     = true


### PR DESCRIPTION
[[issue #85](https://github.com/outerbounds/terraform-aws-metaflow/issues/85)]

The ephemeral_storage is currently not defined in the [metadata-service submodule](https://github.com/outerbounds/terraform-aws-metaflow/blob/master/modules/metadata-service/ecs.tf#L59) so it is set to its default value of 21Gb.

I've added a variable called `metadata_service_ephemeral_storage` which would allow users to define the metadata task disk space in the root module 