### PR TITLE
Update python runtime to 3.12 for db_migrate_lambda

### DIFF
--- a/modules/metadata-service/lambda.tf
+++ b/modules/metadata-service/lambda.tf
@@ -113,7 +113,7 @@ EOF
 resource "aws_lambda_function" "db_migrate_lambda" {
   function_name    = local.db_migrate_lambda_name
   handler          = "index.handler"
-  runtime          = "python3.7"
+  runtime          = "python3.12"
   memory_size      = 128
   timeout          = 900
   description      = "Trigger DB Migration"


### PR DESCRIPTION
Closes #87 

Python 3.7 is no longer supported by AWS for creating or updating Lambdas as of February 8th, 2024. 