### PR TITLE
examples: bump module version to 0.12.0

### DIFF
--- a/examples/eks_airflow/metaflow.tf
+++ b/examples/eks_airflow/metaflow.tf
@@ -20,7 +20,7 @@ data "aws_availability_zones" "available" {
 
 module "metaflow-datastore" {
   source  = "outerbounds/metaflow/aws//modules/datastore"
-  version = "0.8.0"
+  version = "0.12.0"
 
   force_destroy_s3_bucket = true
 
@@ -37,12 +37,12 @@ module "metaflow-datastore" {
 
 module "metaflow-common" {
   source  = "outerbounds/metaflow/aws//modules/common"
-  version = "0.8.0"
+  version = "0.12.0"
 }
 
 module "metaflow-metadata-service" {
   source  = "outerbounds/metaflow/aws//modules/metadata-service"
-  version = "0.8.0"
+  version = "0.12.0"
 
   resource_prefix = local.resource_prefix
   resource_suffix = local.resource_suffix

--- a/examples/eks_argo/metaflow.tf
+++ b/examples/eks_argo/metaflow.tf
@@ -20,7 +20,7 @@ data "aws_availability_zones" "available" {
 
 module "metaflow-datastore" {
   source  = "outerbounds/metaflow/aws//modules/datastore"
-  version = "0.10.0"
+  version = "0.12.0"
 
   force_destroy_s3_bucket = true
 
@@ -37,12 +37,12 @@ module "metaflow-datastore" {
 
 module "metaflow-common" {
   source  = "outerbounds/metaflow/aws//modules/common"
-  version = "0.10.0"
+  version = "0.12.0"
 }
 
 module "metaflow-metadata-service" {
   source  = "outerbounds/metaflow/aws//modules/metadata-service"
-  version = "0.10.0"
+  version = "0.12.0"
 
   resource_prefix = local.resource_prefix
   resource_suffix = local.resource_suffix

--- a/examples/minimal/minimal_example.tf
+++ b/examples/minimal/minimal_example.tf
@@ -38,7 +38,7 @@ module "vpc" {
 
 module "metaflow" {
   source  = "outerbounds/metaflow/aws"
-  version = "0.9.0"
+  version = "0.12.0"
 
   resource_prefix = local.resource_prefix
   resource_suffix = local.resource_suffix


### PR DESCRIPTION
Fixes HTTP 400 errors when applying resources in the `examples/` directory.

<details>

<summary>Fixed errors</summary>

```
│ Error: creating RDS DB Instance (metaflowmetaflow40yrvx6i): InvalidParameterCombination: RDS does not support creating a DB instance with the following combination: DBInstanceClass=db.t2.small, Engine=postgres, EngineVersion=11.22, LicenseModel=postgresql-license. For supported combinations of instance class and database engine version, see the documentation.
│       status code: 400, request id: 40e6e5bb-d95b-47b4-82b8-6b8dc506fc56
│
│   with module.metaflow-datastore.aws_db_instance.this[0],
│   on .terraform/modules/metaflow-datastore/modules/datastore/rds.tf line 98, in resource "aws_db_instance" "this":
│   98: resource "aws_db_instance" "this" {
│
╵
╷
│ Error: creating Lambda Function (metaflowdb_migrate40yrvx6i): operation error Lambda: CreateFunction, https response error StatusCode: 400, RequestID: 445a5bf5-0256-4ab3-a5fe-edfe8029af0b, InvalidParameterValueException: The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.12) while creating or updating functions.
│
│   with module.metaflow-metadata-service.aws_lambda_function.db_migrate_lambda,
│   on .terraform/modules/metaflow-metadata-service/modules/metadata-service/lambda.tf line 115, in resource "aws_lambda_function" "db_migrate_lambda":
│  115: resource "aws_lambda_function" "db_migrate_lambda" {
│
```

</details>
