### PR TITLE
This patch adds the necessary elements for an upgrade of the database…

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ resource "local_file" "metaflow_config" {
 | <a name="input_compute_environment_max_vcpus"></a> [compute\_environment\_max\_vcpus](#input\_compute\_environment\_max\_vcpus) | Maximum VCPUs for Batch Compute Environment [16-96] | `number` | `64` | no |
 | <a name="input_compute_environment_min_vcpus"></a> [compute\_environment\_min\_vcpus](#input\_compute\_environment\_min\_vcpus) | Minimum VCPUs for Batch Compute Environment [0-16] for EC2 Batch Compute Environment (ignored for Fargate) | `number` | `8` | no |
 | <a name="input_db_engine_version"></a> [db\_engine\_version](#input\_db\_engine\_version) | n/a | `string` | `"11"` | no |
-| <a name="input_db_instance_type"></a> [db\_instance\_type](#input\_db\_instance\_type) | RDS instance type to launch for PostgresQL database. | `string` | `"db.t2.small"` | no |
+| <a name="input_db_allow_major_version_upgrade"></a> [db\_allow\_major\_version\_upgrade](#input\_db\_allow\_major\_version\_upgrade) | Allow major version upgrades of the DB. | `bool` | `"false"` | no |
+| <a name="input_db_apply_immediately"></a> [db\_apply\_immediately](#input\_db\_apply\_immediately) | Apply DB changes immediately. | `bool` | `"false"` | no |
 | <a name="input_db_migrate_lambda_zip_file"></a> [db\_migrate\_lambda\_zip\_file](#input\_db\_migrate\_lambda\_zip\_file) | Output path for the zip file containing the DB migrate lambda | `string` | `null` | no |
 | <a name="input_enable_custom_batch_container_registry"></a> [enable\_custom\_batch\_container\_registry](#input\_enable\_custom\_batch\_container\_registry) | Provisions infrastructure for custom Amazon ECR container registry if enabled | `bool` | `false` | no |
 | <a name="input_enable_key_rotation"></a> [enable\_key\_rotation](#input\_enable\_key\_rotation) | Enable key rotation for KMS keys | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -12,8 +12,10 @@ module "metaflow-datastore" {
   subnet1_id                         = var.subnet1_id
   subnet2_id                         = var.subnet2_id
 
-  db_instance_type  = var.db_instance_type
-  db_engine_version = var.db_engine_version
+  db_instance_type               = var.db_instance_type
+  db_engine_version              = var.db_engine_version
+  db_allow_major_version_upgrade = var.db_allow_major_version_upgrade
+  db_apply_immediately           = var.db_apply_immediately
 
   standard_tags = var.tags
 }

--- a/modules/datastore/rds.tf
+++ b/modules/datastore/rds.tf
@@ -58,10 +58,12 @@ locals {
 }
 
 resource "aws_rds_cluster" "this" {
-  count              = local.use_aurora ? 1 : 0
-  cluster_identifier = "${var.resource_prefix}${var.db_name}${var.resource_suffix}"
-  kms_key_id         = aws_kms_key.rds.arn
-  engine             = var.db_engine
+  count                       = local.use_aurora ? 1 : 0
+  cluster_identifier          = "${var.resource_prefix}${var.db_name}${var.resource_suffix}"
+  kms_key_id                  = aws_kms_key.rds.arn
+  engine                      = var.db_engine
+  apply_immediately           = var.db_apply_immediately
+  allow_major_version_upgrade = var.db_allow_major_version_upgrade
 
   database_name        = var.db_name
   master_username      = var.db_username

--- a/modules/datastore/variables.tf
+++ b/modules/datastore/variables.tf
@@ -11,7 +11,17 @@ variable "db_engine" {
 
 variable "db_engine_version" {
   type    = string
-  default = "11"
+  default = "12.17"
+}
+
+variable "db_allow_major_version_upgrade" {
+  type    = bool
+  default = false
+}
+
+variable "db_apply_immediately" {
+  type    = bool
+  default = false
 }
 
 variable "db_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -75,7 +75,17 @@ variable "db_instance_type" {
 
 variable "db_engine_version" {
   type    = string
-  default = "11"
+  default = "12.17"
+}
+
+variable "db_allow_major_version_upgrade" {
+  type    = bool
+  default = false
+}
+
+variable "db_apply_immediately" {
+  type    = bool
+  default = false
 }
 
 variable "launch_template_http_endpoint" {


### PR DESCRIPTION
… engine to

12.17 from 11.

Added are 2 new inputs:

- db_allow_major_version_upgrade
- db_apply_immediately

Default for these is still false allowing the user to make a concious decision about this change.

For reference see the doc from AWS to upgrade from 11 to 12: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion