### PR TITLE
Enabling variables to control job batch limits

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -97,6 +97,10 @@ module "metaflow-computation" {
   launch_template_http_endpoint               = var.launch_template_http_endpoint
   launch_template_http_tokens                 = var.launch_template_http_tokens
   launch_template_http_put_response_hop_limit = var.launch_template_http_put_response_hop_limit
+  job_state_time_limit_action                 = var.job_state_time_limit_action
+  job_state_time_limit_timeout                = var.job_state_time_limit_timeout
+  job_state_time_limit_reason                 = var.job_state_time_limit_reason
+
 
   standard_tags = var.tags
 }

--- a/modules/computation/variables.tf
+++ b/modules/computation/variables.tf
@@ -102,3 +102,18 @@ variable "launch_template_image_id" {
   nullable    = true
   default     = null
 }
+
+variable "job_state_time_limit_action" {
+  type        = string
+  description = "The action to take when the job times out"
+}
+
+variable "job_state_time_limit_timeout" {
+  type        = number
+  description = "The time limit in seconds for the job to run before the action is taken"
+}
+
+variable "job_state_time_limit_reason" {
+  type        = number
+  description = "The reason for the job state time limit action"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -199,3 +199,18 @@ variable "enable_key_rotation" {
   description = "Enable key rotation for KMS keys"
   default     = false
 }
+
+variable "job_state_time_limit_action" {
+  type        = string
+  description = "The action to take when the job times out"
+}
+
+variable "job_state_time_limit_timeout" {
+  type        = number
+  description = "The time limit in seconds for the job to run before the action is taken"
+}
+
+variable "job_state_time_limit_reason" {
+  type        = number
+  description = "The reason for the job state time limit action"
+}


### PR DESCRIPTION
We've been encountering recurring issues with some AWS Batch queues getting stuck in a **Runnable** state. This seems to be caused by resource availability constraints or potential misconfigurations in our workflows. To address this, I'm implementing a Job State Limit for these jobs in the [metaflow-computation](https://github.com/outerbounds/terraform-aws-metaflow/blob/master/modules/computation/batch.tf#L78) module. The AWS [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/batch_job_queue.html#job_state_time_limit_action-1) allows us to extend the capabilities of this resource
Here’s the approach:
-  Introduce an optional variable that allows us to configure the timeout and define the action to take when a job exceeds the allowed state duration.
The benefits of this change are clear:
- It would prevent jobs from running excessively long (In our case we had a run 40+ hours over weekends), which has been blocking new executions and impacting production workloads.
- It addresses an issue several teams have mentioned in Slack threads, making it a valuable improvement for our broader community.